### PR TITLE
Change help link for unofficial branding (Serpent)

### DIFF
--- a/application/basilisk/branding/unofficial/branding.nsi
+++ b/application/basilisk/branding/unofficial/branding.nsi
@@ -12,5 +12,5 @@
 !define CompanyName           "Moonchild Productions"
 !define URLInfoAbout          "https://www.basilisk-browser.org"
 !define URLUpdateInfo         "https://www.basilisk-browser.org"
-!define HelpLink              "https://forum.palemoon.org"
+!define HelpLink              "https://msfn.org/board/topic/177125-my-build-of-new-moon-temp-name-aka-pale-moon-fork-targetting-xp/?do=getNewComment"
 !define URLSystemRequirements "https://www.basilisk-browser.org"

--- a/application/basilisk/branding/unofficial/pref/basilisk-branding.js
+++ b/application/basilisk/branding/unofficial/pref/basilisk-branding.js
@@ -19,7 +19,7 @@ pref("startup.homepage_welcome_url", "");
 pref("startup.homepage_welcome_url.additional", "");
 
 // Version release notes
-pref("app.releaseNotesURL", "about:blank");
+pref("app.releaseNotesURL", "https://rtfreesoft.blogspot.com/search/label/serpent");
 
 // Vendor home page
 pref("app.vendorURL", "about:");

--- a/application/palemoon/branding/unofficial/branding.nsi
+++ b/application/palemoon/branding/unofficial/branding.nsi
@@ -12,5 +12,5 @@
 !define CompanyName           "Moonchild Productions"
 !define URLInfoAbout          "http://www.palemoon.org"
 !define URLUpdateInfo         "http://www.palemoon.org"
-!define HelpLink              "http://www.palemoon.org"
+!define HelpLink              "https://msfn.org/board/topic/177125-my-build-of-new-moon-temp-name-aka-pale-moon-fork-targetting-xp/?do=getNewComment"
 !define URLSystemRequirements "http://www.palemoon.org/download.shtml"

--- a/application/palemoon/branding/unofficial/pref/palemoon-branding.js
+++ b/application/palemoon/branding/unofficial/pref/palemoon-branding.js
@@ -3,8 +3,8 @@
 #include ../../shared/pref/preferences.inc
 #include ../../shared/pref/uaoverrides.inc
 
-pref("startup.homepage_override_url","http://www.palemoon.org/unofficial.shtml");
-pref("app.releaseNotesURL", "http://www.palemoon.org/releasenotes.shtml");
+pref("startup.homepage_override_url","");
+pref("app.releaseNotesURL", "https://rtfreesoft.blogspot.com/search/label/newmoon");
 
 // Updates disabled
 pref("app.update.enabled", false);


### PR DESCRIPTION
Serpent Help / Submit Feedback option currently links to Pale Moon forum. This is fine for official builds, but for unofficial builds, it invites feedback that the forum doesn't want to deal with. This change redirects Submit Feedback to a topic at msfn.org devoted to unofficial builds of Serpent.