### PR TITLE
Hidden preference to toggle addon version in addon manager

### DIFF
--- a/toolkit/mozapps/extensions/content/extensions.xml
+++ b/toolkit/mozapps/extensions/content/extensions.xml
@@ -1174,7 +1174,8 @@
           else
             this._icon.src = "";
 
-          if (shouldShowVersionNumber(this.mAddon))
+          if (shouldShowVersionNumber(this.mAddon) &&
+            Services.prefs.getBoolPref("extensions.addonVersionInfo", true))
             this._version.value = this.mAddon.version;
           else
             this._version.hidden = true;

--- a/toolkit/mozapps/webextensions/content/extensions.css
+++ b/toolkit/mozapps/webextensions/content/extensions.css
@@ -249,6 +249,7 @@ richlistitem:not([selected]) * {
 .view-pane[type="experiment"] .addon:not([pending="uninstall"]) .pending,
 .view-pane[type="experiment"] .disabled-postfix,
 .view-pane[type="experiment"] .update-postfix,
+.view-pane[type="experiment"] .version,
 .view-pane[type="experiment"] .addon-control.enable,
 .view-pane[type="experiment"] .addon-control.disable,
 #detail-view[type="experiment"] .alert-container,

--- a/toolkit/mozapps/webextensions/content/extensions.xml
+++ b/toolkit/mozapps/webextensions/content/extensions.xml
@@ -1121,7 +1121,8 @@
             this._icon.src = iconURL;
           else
             this._icon.src = "";
-          if (shouldShowVersionNumber(this.mAddon))
+          if (shouldShowVersionNumber(this.mAddon) &&
+            Services.prefs.getBoolPref("extensions.addonVersionInfo", true))
             this._version.value = this.mAddon.version;
           else
             this._version.hidden = true;

--- a/toolkit/mozapps/webextensions/content/extensions.xml
+++ b/toolkit/mozapps/webextensions/content/extensions.xml
@@ -808,6 +808,7 @@
               <xul:hbox class="name-container">
                 <xul:label anonid="name" class="name" crop="end" flex="1"
                            tooltip="addonitem-tooltip" xbl:inherits="value=name"/>
+                <xul:label anonid="version" class="version"/>
                 <xul:label class="disabled-postfix" value="&addon.disabled.postfix;"/>
                 <xul:label class="update-postfix" value="&addon.update.postfix;"/>
                 <xul:spacer flex="5000"/> <!-- Necessary to make the name crop -->
@@ -986,6 +987,9 @@
         document.getAnonymousElementByAttribute(this, "anonid",
                                                 "info");
       </field>
+      <field name="_version"> 
+        document.getAnonymousElementByAttribute(this, "anonid", "version");
+      </field>
       <field name="_experimentState">
         document.getAnonymousElementByAttribute(this, "anonid", "experiment-state");
       </field>
@@ -1117,7 +1121,10 @@
             this._icon.src = iconURL;
           else
             this._icon.src = "";
-
+          if (shouldShowVersionNumber(this.mAddon))
+            this._version.value = this.mAddon.version;
+          else
+            this._version.hidden = true;
           if (this.mAddon.description)
             this._description.value = this.mAddon.description;
           else
@@ -1402,7 +1409,13 @@
           }
         ]]></body>
       </method>
-
+      <method name="_updateUpgradeInfo">
+        <body><![CDATA[
+          // Only update the version string if we're displaying the upgrade info
+          if (this.hasAttribute("upgrade") && shouldShowVersionNumber(this.mAddon))
+            this._version.value = this.mManualUpdate.version;
+        ]]></body>
+      </method>
       <method name="_fetchReleaseNotes">
         <parameter name="aURI"/>
         <body><![CDATA[
@@ -1689,6 +1702,7 @@
 
           this.mManualUpdate = aInstall;
           this._showStatus("update-available");
+          this._updateUpgradeInfo();
         ]]></body>
       </method>
 
@@ -1891,6 +1905,7 @@
         <xul:vbox class="fade name-outer-container" flex="1">
           <xul:hbox class="name-container">
             <xul:label anonid="name" class="name" crop="end" tooltip="addonitem-tooltip"/>
+            <xul:label anonid="version" class="version" hidden="true"/>
           </xul:hbox>
         </xul:vbox>
         <xul:vbox class="install-status-container">
@@ -1911,6 +1926,9 @@
       </field>
       <field name="_name">
         document.getAnonymousElementByAttribute(this, "anonid", "name");
+      </field>
+      <field name="_version">
+        document.getAnonymousElementByAttribute(this, "anonid", "version");
       </field>
       <field name="_warning">
         document.getAnonymousElementByAttribute(this, "anonid", "warning");
@@ -1939,6 +1957,12 @@
             this._icon.src = this.mAddon.iconURL ||
                              (this.mInstall ? this.mInstall.iconURL : "");
             this._name.value = this.mAddon.name;
+            if (this.mAddon.version) {
+              this._version.value = this.mAddon.version;
+              this._version.hidden = false;
+            } else {
+              this._version.hidden = true;
+            }
           } else {
             this._icon.src = this.mInstall.iconURL;
             // AddonInstall.name isn't always available - fallback to filename
@@ -1951,6 +1975,12 @@
                        null, null);
               url.QueryInterface(Components.interfaces.nsIURL);
               this._name.value = url.fileName;
+            }
+            if (this.mInstall.version) {
+              this._version.value = this.mInstall.version;
+              this._version.hidden = false;
+            } else {
+              this._version.hidden = true;
             }
           }
 


### PR DESCRIPTION
Puts Show addon version in addon manager addon list behind user preference "extensions.addonVersionInfo", currently on by default
Commit ported from Waterfox